### PR TITLE
Resource update

### DIFF
--- a/Include/ResourceManagement/Resource.h
+++ b/Include/ResourceManagement/Resource.h
@@ -15,7 +15,7 @@ static Ref createRef(ResourceManager& resMngr, Args... args) { \
     static_assert(std::is_base_of<ResourceBase, Res>::value); \
     Res* res = new Res(args...); \
     resMngr.addResource(res); \
-    return Ref(res->getResource()); \
+    return Ref(*res); \
 }
 
 class ResourceBase {
@@ -32,8 +32,12 @@ class Resource : public ResourceBase {
         Resource() { }
         Resource(const Resource<T>& other) = delete;
         Resource<T>& operator=(const Resource<T>& other) = delete;
-        const T& getResource() const { return resource; }
-        const T* getResourcePointer() const { return &resource; }
+
+        operator const T& () const { return resource; }
+        // Force cast.
+        const T& operator()() const { return resource; }
+        const T& operator->() const { return resource; }
+        const T* operator&() const { return &resource; }
 };
 
 }

--- a/Include/ResourceManagement/ResourceManager.h
+++ b/Include/ResourceManagement/ResourceManager.h
@@ -6,7 +6,6 @@
 #include <Exception/Exception.h>
 
 #include "Resource.h"
-#include "ResourceReference.h"
 
 namespace PGE {
 
@@ -36,7 +35,7 @@ class ResourceManager {
             for (auto it = resources.end(); it > resources.begin();) {
                 it--;
                 Resource<T>* specifiedResource = dynamic_cast<Resource<T>*>(*it);
-                if (specifiedResource != nullptr && specifiedResource->getResource() == internalResource) {
+                if (specifiedResource != nullptr && (*specifiedResource)() == internalResource) {
                     delete specifiedResource;
                     resources.erase(it);
                     reference.invalidate();

--- a/Include/ResourceManagement/ResourceReference.h
+++ b/Include/ResourceManagement/ResourceReference.h
@@ -13,11 +13,13 @@ class ResourceReference {
     public:
         ResourceReference() { }
         ResourceReference(T res) { internalResource = res; holdsResource = true; }
+
         operator const T&() const { assert(holdsResource); return internalResource; }
         // Force cast.
         const T& operator()() const { assert(holdsResource); return internalResource; }
         const T& operator->() const { assert(holdsResource); return internalResource; }
         const T* operator&() const { assert(holdsResource); return &internalResource; }
+
         bool isHoldingResource() const { return holdsResource; }
         void invalidate() { holdsResource = false; }
 };

--- a/Src/Graphics/GraphicsDX11.h
+++ b/Src/Graphics/GraphicsDX11.h
@@ -8,10 +8,6 @@
 #include <d3d11.h>
 
 #include <ResourceManagement/ResourceReferenceVector.h>
-#include <ResourceManagement/ResourceReference.h>
-#include <ResourceManagement/ResourceManager.h>
-#include <ResourceManagement/Resource.h>
-
 #include "../ResourceManagement/DX11.h"
 
 namespace PGE {

--- a/Src/ResourceManagement/DX11.h
+++ b/Src/ResourceManagement/DX11.h
@@ -3,7 +3,6 @@
 
 #include <Exception/Exception.h>
 
-#include <ResourceManagement/Resource.h>
 #include <ResourceManagement/ResourceManager.h>
 
 #include <d3d11.h>

--- a/Src/ResourceManagement/Misc.h
+++ b/Src/ResourceManagement/Misc.h
@@ -4,7 +4,6 @@
 #include <Misc/String.h>
 #include <Exception/Exception.h>
 
-#include <ResourceManagement/Resource.h>
 #include <ResourceManagement/ResourceManager.h>
 
 #include <SysEvents/SysEvents.h>

--- a/Src/ResourceManagement/OGL3.h
+++ b/Src/ResourceManagement/OGL3.h
@@ -5,7 +5,6 @@
 
 #include <Exception/Exception.h>
 
-#include <ResourceManagement/Resource.h>
 #include <ResourceManagement/ResourceManager.h>
 
 #include <GL/glew.h>

--- a/Src/Shader/ShaderDX11.h
+++ b/Src/Shader/ShaderDX11.h
@@ -92,7 +92,7 @@ class ShaderDX11 : public Shader {
             public:
                 CBufferInfoOwner(Graphics* gfx, String nm, int sz, ResourceManager* rm);
 
-                __RES_MNGMT__REF_FACT_METH(CBufferInfoOwner, CBufferInfoRef)
+                __RES_MNGMT__REF_FACT_METH(CBufferInfoOwner, CBufferInfo*)
         };
 
         ResourceReferenceVector<CBufferInfo*> vertexConstantBuffers;


### PR DESCRIPTION
It has proven itself to be quite convenient to use the pure Resource as a value type for temporary variables. The deletion of copy constructor and assignment operator should prevent misuse.